### PR TITLE
Add hyphen as a valid character of Process Types

### DIFF
--- a/syntax/procfile.vim
+++ b/syntax/procfile.vim
@@ -14,7 +14,7 @@ syn region procfileLine    start='^'      end='$' oneline contains=procfileComme
 syn region procfileComment start='#'      end='$' oneline contained
 syn region procfileBundle  start='bundle' end='$' oneline contained contains=procfileEnvSetting,procfileComment,procfileVariable
 
-syn match procfileName    /^\w\+:/ contained contains=procfileInvalidName,procfileValidName 
+syn match procfileName    /^[[:alnum:]_-]\+:/ contained contains=procfileInvalidName,procfileValidName
 syn region procfileInvalidName start='^' end=':'                          oneline contained
 syn region procfileValidName   start='^' end='\(web\|_worker\|_handler\|_scheduler\|_listener\):' oneline contained
 


### PR DESCRIPTION
Thank you for this project.

This patch allows hyphen contained strings are as a valid Process Type as below.

```Procfile
foobar: run server1
foo_bar: run server2
foo-bar: run server3
```

It seems that this format is right according to some documents.

- > Process types can be any alphanumeric string (hyphens and underscores are also allowed).
    - https://devcenter.heroku.com/articles/preparing-a-codebase-for-heroku-deployment#3-add-a-procfile
- > - `<process type>` – any character in the class `[A-Za-z0-9_-]+`, a process type is a name for your command, such as `web`, `worker`, `urgentworker`, `clock`, etc. 
    - https://github.com/dokku/procfile-util/blob/master/PROCFILE_FORMAT.md#general-overview

Best regards.