### PR TITLE
Match more complex variable substitution

### DIFF
--- a/syntax/procfile.vim
+++ b/syntax/procfile.vim
@@ -24,7 +24,11 @@ syn match procfileEnvSetting    /\s\S\+=\S\+/ contained contains=procfileEnvAssi
 syn match procfileEnvAssignment /=\S\+/       contained contains=procfileEnvOperator
 syn match procfileEnvOperator   /=/           contained
 
-syn match procfileVariable /\$\w\+/ contained
+syn match procfileVariable /\v\$\w+/ contained
+" Match variable w/brackets {} around it
+syn match procfileVariable /\v\$\{\w+\}/ contained
+" Match variable w/brackets {} around it and defaulting null/undefined/etc.
+syn match procfileVariable /\v\$\{\w+:[-=?+]\w+\}/ contained
 
 hi def link procfileBundle        Normal
 hi def link procfileComment       Comment

--- a/syntax/procfile.vim
+++ b/syntax/procfile.vim
@@ -16,7 +16,7 @@ syn region procfileBundle  start='bundle' end='$' oneline contained contains=pro
 
 syn match procfileName    /^\w\+:/ contained contains=procfileInvalidName,procfileValidName 
 syn region procfileInvalidName start='^' end=':'                          oneline contained
-syn region procfileValidName   start='^' end='\(web\|_worker\|_handler\|_scheduler\|_listener\):' oneline contained
+syn region procfileValidName   start='^' end='\v\w+[_\w]?:' oneline contained
 
 syn region procfileEnv     start='env' end='$' oneline contained contains=procfileBundle,procfileEnvSetting,procfileEnvProg transparent
 syn keyword procfileEnvProg env contained

--- a/syntax/procfile.vim
+++ b/syntax/procfile.vim
@@ -14,9 +14,9 @@ syn region procfileLine    start='^'      end='$' oneline contains=procfileComme
 syn region procfileComment start='#'      end='$' oneline contained
 syn region procfileBundle  start='bundle' end='$' oneline contained contains=procfileEnvSetting,procfileComment,procfileVariable
 
-syn match procfileName    /^\w\+:/ contained contains=procfileInvalidName,procfileValidName 
-syn region procfileInvalidName start='^' end=':'                          oneline contained
-syn region procfileValidName   start='^' end='\v\w+[_\w]?:' oneline contained
+syn match procfileName    /^[[:alnum:]_-]\+:/ contained contains=procfileInvalidName,procfileValidName
+syn region procfileInvalidName start='^' end=':'                    oneline contained
+syn region procfileValidName   start='^' end='\v\w+[[:alnum:]_-]?:' oneline contained
 
 syn region procfileEnv     start='env' end='$' oneline contained contains=procfileBundle,procfileEnvSetting,procfileEnvProg transparent
 syn keyword procfileEnvProg env contained


### PR DESCRIPTION
1. Allow word-characters and underscore process type names:
   A `Procfile` entry doesn't need to end in `_worker`, `_handler`, etc… to be valid. For example, `release` is a special entry in a Heroku Procfile, but it shows up as invalid. Similarly names like `sidekiq` or `stream_consumer` are valid.

   This loosens the regex to require at least one word character, and then
optionally any number of underscores, dashes, or word characters, ending in a
colon. This should also address #1.

2. Allow more complex variable substitution:
   Some environments where `Procfile`s are  used (like Heroku), [variable substitution follows Bash's syntax for providing defaults and such](https://emmer.dev/blog/bash-environment-variable-defaults/). This adds support for that style. An example (roughly) from a production app:

   ```
   sidekiq: SIDEKIQ_COUNT="${SIDEKIQ_PROC_COUNT:-2}" DB_POOL="$((${SIDEKIQ_CONCURRENCY:-4}+${SIDEKIQ_CAPSULE_CONCURRENCY:-1}))" bin/sidekiqswarm -C config/sidekiq.yml
   ```